### PR TITLE
Git latest-pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use it with:
 - `git list-branches [-l] [-r] [-i integration-branch]` Colourful listing of all local or origin branches, and their distance to an integration branch (`master` by default).
 - `git merge-po <ancestor> <left> <right>` Merge engine for GetText PO files.
 - `git select <story-id>` Checkout a local branch with the matching number. If not found, lists remote branches
-- `git latest [-n NR_RESULTS] [-p PATTERN]` Show latest pushed branches to origin. Defaults to 20 results. Pattern is appended to refs/remotes/origin/ so include the team or project name to filter results. [[PedroCunha](https://github.com/PedroCunha)]
+- `git latest-pushes [-n NR_RESULTS] [-p PATTERN]` Show latest pushed branches to origin. Defaults to 20 results. Pattern is appended to refs/remotes/origin/ so include the team or project name to filter results. [[PedroCunha](https://github.com/PedroCunha)]
 
 ### More details on some of the commands
 

--- a/bin/git-latest-pushes
+++ b/bin/git-latest-pushes
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 #
-# git-latest --
+# git-latest-pushes --
 #
 # List of latest pushed branches on origin
 #
@@ -45,7 +45,7 @@ class App < Git::Whistles::App
     @option_parser ||= OptionParser.new do |op|
       op.banner = %Q{
 Returns the list of latest pushed branches on origin
-Usage: git latest [-n NR_RESULTS] [-p PATTERN]
+Usage: git latest-pushes [-n NR_RESULTS] [-p PATTERN]
       }
 
       op.on("-n", "--n [NR_RESULTS]", "Number of results to display, defaults to 20") do |n|


### PR DESCRIPTION
Show latest pushed branches to origin. 

Defaults to 20 results

You can specify a pattern like

`git latest-pushes -p hosts-nps`

:rocket: 

You can specify amount of results

`git latest-pushes -n 50`
