### PR TITLE
Add the command "git pt ID" to name branches from Pivotal Tracker tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 pkg
 rdoc
 tmp
+nbproject

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Use it with:
 
 - `git ff-all-branches [-f] [-p] [-v]`. Fast-forward all local tracking branches to their remote counterpart (where possible). Very useful on big projects.
 - `git stash-and-checkout [branch]` As the name implies: stash and checkout another branch.
-- `git-pull-request [--from your-branch] [--to target-branch]` Open your browser at a Github pull-request page for the specified branch (defaults to the current `head`). If you're using Pivotal Tracker and your branch has a story number in its name, populates your pull request with story details.
+- `git pull-request [--from your-branch] [--to target-branch]` Open your browser at a Github pull-request page for the specified branch (defaults to the current `head`). If you're using Pivotal Tracker and your branch has a story number in its name, populates your pull request with story details.
 - `git outstanding-features [-f from-branch] [-t to-branch]` List the pull requests merged in `[to-branch]` but not in `[from-branch]`. Useful to prepare a list of stuff you're going to deploy. Defaults to listing what's on `origin/master` but not on `origin/production`. [[PedroCunha](https://github.com/PedroCunha)] 
 - `git chop [branch]` Delete the local and origin copy of a branch. Useful to close feature branches once a feature is completed.
 - `git list-branches [-l] [-r] [-i integration-branch]` Colourful listing of all local or origin branches, and their distance to an integration branch (`master` by default).
 - `git merge-po <ancestor> <left> <right>` Merge engine for GetText PO files.
 - `git select <story-id>` Checkout a local branch with the matching number. If not found, lists remote branches
 - `git latest-pushes [-n NR_RESULTS] [-p PATTERN]` Show latest pushed branches to origin. Defaults to 20 results. Pattern is appended to refs/remotes/origin/ so include the team or project name to filter results. [[PedroCunha](https://github.com/PedroCunha)]
+- `git pivotal-branch <story-id>` Creates a branch name suggestion from the specified Pivotal Tracker story ID. [[dncrht](https://github.com/dncrht)]
 
 ### More details on some of the commands
 

--- a/bin/git-pivotal-branch
+++ b/bin/git-pivotal-branch
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# git-pivotal-branch
+# 
+#   Suggest a branch name from the given Pivotal Tracker story ID
+# 
+#   Assumes the branches are named as:
+#   <team>/<branch-title>-<story-id>
+# 
+require 'rubygems'
+require 'optparse'
+require 'pivotal-tracker'
+require 'readline'
+require 'term/ansicolor'
+require 'git-whistles/app'
+
+
+class App < Git::Whistles::App
+
+  def initialize
+    super
+  end
+
+  def main(args)
+    super
+    parse_args!(args)
+
+    if args.count < 1
+      show_and_exit usage
+    end
+
+    story_id = args[0]
+
+    # get PT info
+    story, project = get_pivotal_info(story_id)
+
+    branch_name_suggested = "#{project.name}/#{story.name}-#{story_id}".downcase
+    branch_name_suggested.gsub!(/[^\w\d\/]/, '-').gsub!(/-+/, '-')
+
+    puts 'The suggested branch name is: ' << Term::ANSIColor.yellow(branch_name_suggested)
+    puts '    Press ENTER if you agree'
+    puts ' or Write any other name and press ENTER'
+    puts ' or Press CTRL-D to cancel'
+
+    branch_name = Readline.readline '  > ', false
+
+    if branch_name.nil?
+      log.warn "\nCancelled by user"
+      exit 2
+    end
+
+    branch_name = branch_name.empty? ? branch_name_suggested : branch_name
+
+    # create branch
+    `cd #{ENV['PWD']} && git co -b #{branch_name}`
+
+    # comment and start on PT
+    story.notes.create :text => "Created branch #{branch_name}"
+    story.update :current_state => 'started'
+
+    puts Term::ANSIColor.green('Created branch and started PT story')
+  end
+
+  private
+  
+  def usage
+    'Usage: git pivotal-branch PIVOTAL_TRACKER_STORY_ID'
+  end
+  
+  def show_and_exit(message)
+    puts message
+    exit 1
+  end
+  
+  def option_parser
+    @option_parser ||= OptionParser.new do |op|
+      op.banner = usage
+
+      op.on_tail('-h', '--help', 'Show this message') do
+        show_and_exit op
+      end
+    end
+  end
+
+  def get_pivotal_info(story_id)
+    token = `git config pivotal-tracker.token`.strip
+    if token.empty?
+      puts Term::ANSIColor.yellow %Q{
+        Your branch appears to have a story ID,
+        but I don't know your Pivotal Tracker token!
+        Please set it with:
+        $ git config [--global] pivotal-tracker.token <token>
+      }
+      die "Aborting."
+    end
+
+    log.info "Finding your project and story¬"
+
+    PivotalTracker::Client.token = token
+    story, project = PivotalTracker::Project.all.find do |project|
+      log.info '.¬'
+      story = project.stories.find(story_id) and break story, project
+    end
+    log.info '.'
+
+    if story.nil?
+      log.warn "Apologies... I could not find story #{story_id}."
+      exit 1
+    end
+
+    log.info "Found story #{story_id} in '#{project.name}'"
+
+    [story, project]
+  end
+
+
+end
+
+############################################################################
+
+App.run!


### PR DESCRIPTION
This is the expected output:

$ ./bin/git-pt 49924493
Finding your project and story....
Found story 49924493 in 'Host SQS - Mobile'
This is the suggested branch name. Press enter if you agree, rewrite again if you want another one:
host-sqs-mobile/checkin/out-times-per-booking-49924493

git co -b host-sqs-mobile/checkin/out-times-per-booking-49924493
Switched to a new branch 'host-sqs-mobile/checkin/out-times-per-booking-49924493'
