### PR TITLE
Force branch removal when chopping

### DIFF
--- a/libexec/git-chop.sh
+++ b/libexec/git-chop.sh
@@ -20,5 +20,5 @@ if [ "$branch" = "$current_branch" ] ; then
   git checkout master || die
 fi
 
-git branch -d "$branch" || die
+git branch -D "$branch" || die
 git push origin ":$branch" || die


### PR DESCRIPTION
The chop command is super useful but today I tried to run against a branch and complained.
So to avoid that let's force the removal with -D
