### PR TITLE
Fix gem install on Ruby 1.8.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     git-whistles (0.7.7)
+      mime-types (~> 1.24)
+      nokogiri (~> 1.5.10)
       pivotal-tracker (~> 0.5.6)
       term-ansicolor
 
@@ -12,23 +14,23 @@ GEM
     coderay (1.0.9)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
-    happymapper (0.4.0)
+    happymapper (0.4.1)
       libxml-ruby (~> 2.0)
     libxml-ruby (2.7.0)
     method_source (0.8.2)
-    mime-types (1.24)
-    mini_portile (0.5.1)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
-    nokogiri-happymapper (0.5.7)
+    mime-types (1.25)
+    nokogiri (1.5.10)
+    nokogiri-happymapper (0.5.8)
       nokogiri (~> 1.5)
-    pivotal-tracker (0.5.10)
+    pivotal-tracker (0.5.12)
+      builder
       builder
       crack
       happymapper (>= 0.3.2)
       nokogiri (>= 1.4.3)
       nokogiri (>= 1.5.5)
       nokogiri-happymapper (>= 0.5.4)
+      rest-client (~> 1.6.0)
       rest-client (~> 1.6.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -39,11 +41,11 @@ GEM
     rake (10.1.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    safe_yaml (0.9.5)
+    safe_yaml (0.9.7)
     slop (3.4.6)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
-    tins (0.9.0)
+    tins (0.13.1)
 
 PLATFORMS
   ruby

--- a/git-whistles.gemspec
+++ b/git-whistles.gemspec
@@ -20,6 +20,11 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
 
+  if RUBY_VERSION < "1.9"
+    gem.add_dependency "nokogiri",        "~> 1.5.10"
+    gem.add_dependency "mime-types",      "~> 1.24"
+  end
+ 
   gem.add_dependency "pivotal-tracker", "~> 0.5.6"
   gem.add_dependency "term-ansicolor"
 


### PR DESCRIPTION
Provide 1.8.7 compatible versions of:
- nokogiri ~> 1.5.10
- mime-types ~> 1.24
