### PR TITLE
Allows partial matching on latest-features

### DIFF
--- a/bin/git-latest-pushes
+++ b/bin/git-latest-pushes
@@ -20,11 +20,12 @@ class App < Git::Whistles::App
     super
     parse_args!(args)
 
-    results = `git for-each-ref --sort=-committerdate --count=#{options.results} refs/remotes/origin/#{options.pattern} --format='[%(committerdate:relative)] (%(authorname)) %(refname)'`
+    results = `git for-each-ref --sort=-committerdate --format='[%(committerdate:relative)] (%(authorname)) %(refname)' refs/remotes/origin/ | grep '#{options.pattern}'`
     results = results.split("\n")
 
     if results.any?
-      puts "Latest #{ [results.length, options.results].min } pushed branches:"
+      results = results.slice(0, [results.length, options.nr_results].min)
+      puts "Latest #{ results.length } pushed branches:"
 
       results.each do |branch|
         puts branch.gsub('refs/remotes/origin/', '')
@@ -36,7 +37,7 @@ class App < Git::Whistles::App
 
   def defaults
     {
-      :results => 20,
+      :nr_results => 20,
       :pattern => ''
     }
   end
@@ -49,7 +50,7 @@ Usage: git latest-pushes [-n NR_RESULTS] [-p PATTERN]
       }
 
       op.on("-n", "--n [NR_RESULTS]", "Number of results to display, defaults to 20") do |n|
-        options.nr_results = n
+        options.nr_results = n.to_i
       end
 
       op.on("-p", "--p [PATTERN]", "Pattern to lookup. Eg. -p my-team-name") do |pattern|


### PR DESCRIPTION
Before this was relying on pattern for git for-each-ref however
it only allowed matching branch names between slashes.

Eg.: refs/remotes/origin/foo-branch/

-p foo # no match
-p foo-branch # matches

This now keeps the same API as before (-p pattern) but allows partial
matching so -p foo and -f foo-branch both yield the same results for
the same scenario

This closes #24 
