### PR TITLE
Fixes regexp on outstanding features. Closes #23

### DIFF
--- a/bin/git-outstanding-features
+++ b/bin/git-outstanding-features
@@ -25,7 +25,7 @@ class App < Git::Whistles::App
 
     output = []
     merges.lines.each do |merge|
-      merge.match /(#\d+).*from(.*)/ 
+      merge.match /(#\d+).*from (.*)/ 
       output << $1.strip + ' ' + $2.strip
     end
 


### PR DESCRIPTION
Fix regex on outstanding features for "from" named branches

This closes #23 
