### PR TITLE
Git explore allow line reference

### DIFF
--- a/bin/git-explore
+++ b/bin/git-explore
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 #
-# git-explore [-r ref] [-p path]
+# git-explore [-r ref] [-p path] [-l line[-line]]
 #
 #   Explore the given reference on the remote origin website
 #
@@ -12,28 +12,31 @@ require 'git-whistles/app'
 
 class App < Git::Whistles::App
 
-  GITHUB_URL = 'https://www.github.com'
+  GITHUB_URL = 'https://github.com'
 
   def main(args)
     super
     parse_args!(args)
 
-    remote_origin_url = run!("git config --get remote.origin.url").strip
+    @origin = run!("git config --get remote.origin.url").strip
 
-    die 'Unknown origin. Only github supported at the moment', :usage => true unless github?(remote_origin_url)
+    unless github?
+      die 'Unknown origin. Only github supported at the moment', usage: true
+    end
 
     # This has to support both variants
     # https://github.com/mezis/git-whistles.git
     # git@github.com:mezis/git-whistles.git
-    remote_origin_url.match /github\.com[:\/](.+)\.git/
-
-    die "Error parsing #{remote_origin_url} could not find repo" unless $1
+    unless @origin.match /github\.com[:\/](.+)\.git/
+      die "Error parsing #{@origin} could not find repo"
+    end
 
     repo      = $1
-    reference = "tree/#{ options.ref.strip }"
-    path      = options.path ? "#{ options.path.strip }" : ''
+    path      = options.path          ? "/#{ options.path.strip }" : nil
+    reference = path                  ? "/blob/#{ options.ref.strip }" : "/tree/#{ options.ref.strip }"
+    lines     = path && options.lines ? "##{options.lines.split('-').map{ |line| "L#{line}" }.join('-')}" : ''
 
-    url = "#{GITHUB_URL}/#{repo}/#{reference}/#{path}"
+    url = "#{GITHUB_URL}/#{repo}#{reference}#{path}#{lines}"
 
     puts "opening #{ url }..."
     run! "open #{ url }"
@@ -41,24 +44,28 @@ class App < Git::Whistles::App
 
   def defaults
     {
-      :ref  => run!('git rev-parse --abbrev-ref HEAD'),
-      :file => nil
+      ref:  run!('git rev-parse --abbrev-ref HEAD'),
+      file: nil
     }
   end
 
   def option_parser
     @option_parser ||= OptionParser.new do |op|
-      op.banner = "Usage: git explore [-b branch] [-f file]"
+      op.banner = "Usage: git explore [-r ref] [-p path] [-l line[-line]]"
 
-      op.on("-r", "--ref REFERENCE", "Reference to explore. Defaults to current branch") do |ref|
+      op.on('-r', '--ref REFERENCE', 'Reference to explore. Defaults to current branch') do |ref|
         options.ref = ref
       end
 
-      op.on("-p", "--path PATH", "Path to explore. Defaults to /") do |path|
+      op.on('-p', '--path PATH', 'Path to explore. Defaults to /') do |path|
         options.path = path
       end
 
-      op.on_tail("-h", "--help", "Show this message") do
+      op.on('-l', '--line LINE', 'Line(s) to highlight. Examples: "2", "10-15". Defaults to nil') do |lines|
+        options.lines = lines
+      end
+
+      op.on_tail('-h', '--help', 'Show this message') do
         puts op
         exit
       end
@@ -66,8 +73,9 @@ class App < Git::Whistles::App
   end
 
   private
-  def github?(origin)
-    origin.match %r{github.com} 
+
+  def github?
+    @origin.match %r{github.com}
   end
 
 end


### PR DESCRIPTION
This allows `git explore` to receive a `-l line[-line]` to highlight the lines in the target path. This option is only valid if a path is supplied.
