### PR TITLE
Do not fail on blank Jira issue description

### DIFF
--- a/bin/git-jira-pr
+++ b/bin/git-jira-pr
@@ -122,12 +122,8 @@ class App < Git::Whistles::App
 
     title       = "#{issue_id}: #{issue.summary}"
     headline    = "Jira story [##{issue_id}](#{@client.options[:site]}/browse/#{issue_id}) in project *#{issue.project.name}*:"
-    description = issue.description.split("\n").map do |line|
-      (1..6).each { |i| line.gsub!(/(h#{i}.)/, '#' * i) }
-      line.gsub!(/({{)|(}})/, '`')
-      "> #{line}"
-    end.join("\n")
 
+    description = safe_description(issue.description)
     query.merge! subject: issue.summary, :"pull_request[title]" => title
 
     if (headline.length + description.length) > SAFE_QUERY_STRING_SIZE
@@ -147,6 +143,16 @@ class App < Git::Whistles::App
       body = "TODO: describe your changes\n\n===\n\n#{headline}\n\n#{description}"
       query.merge! :"pull_request[body]" => body
     end
+  end
+
+  def safe_description(description)
+    return '' unless description
+
+    description.split("\n").map do |line|
+      (1..6).each { |i| line.gsub!(/(h#{i}.)/, '#' * i) }
+      line.gsub!(/({{)|(}})/, '`')
+      "> #{line}"
+    end.join("\n")
   end
 
   def launch_browser(url)


### PR DESCRIPTION
Related to [#53](https://github.com/mezis/git-whistles/issues/53).

Just handle blank description case and return empty string rather than attempting to parse it.