### PR TITLE
Strip leading/trailing whitespace from project names

### DIFF
--- a/lib/git-whistles/pull_request/jira.rb
+++ b/lib/git-whistles/pull_request/jira.rb
@@ -36,7 +36,7 @@ module Git
           log.info "Found story #{issue_id} in '#{issue.fields['project']['name']}'"
 
           title       = "#{issue_id}: #{issue.summary}"
-          headline    = "Jira story [##{issue_id}](#{client.options[:site]}/browse/#{issue_id}) in project *#{issue.project.name}*:"
+          headline    = "Jira story [##{issue_id}](#{client.options[:site]}/browse/#{issue_id}) in project *#{issue.project.name.strip}*:"
 
           description = safe_description(issue.description)
           params[:subject] = issue.summary

--- a/lib/git-whistles/pull_request/pivotal.rb
+++ b/lib/git-whistles/pull_request/pivotal.rb
@@ -48,7 +48,7 @@ module Git
           log.info "Found story #{story_id} in '#{project.name}'"
 
           title       = "#{project.name}: #{story.name} [##{story.id}]"
-          headline    = "Pivotal tracker story [##{story_id}](#{story.url}) in project *#{project.name}*:"
+          headline    = "Pivotal tracker story [##{story_id}](#{story.url}) in project *#{project.name.strip}*:"
           description = story.description.split("\n").map { |line| "> #{line}" }.join("\n")
           params[:subject] = story.name
           params[:'pull_request[title]'] = title


### PR DESCRIPTION
JIRA doesn't strip trailing whitespace from project names, so headlines end up
looking unintentionally ugly.